### PR TITLE
Fixed type errors testing for new version of node 10.x+

### DIFF
--- a/test.js
+++ b/test.js
@@ -42,8 +42,8 @@ test('listDirectories()', async t => {
 	try {
 		await listDirectories([0, 1]);
 		fail();
-	} catch ({name}) {
-		t.equal(name, 'TypeError', 'should fail when it takes a non-string argument.');
+	} catch ({code}) {
+		t.equal(code, 'ERR_INVALID_ARG_TYPE', 'should fail when it takes a non-string argument.');
 	}
 
 	try {


### PR DESCRIPTION
When I run the test in a recent version of node `v10.9.0`, it gives me the below error

```
not ok 4 should fail when it takes a non-string argument.
  ---
    operator: equal
    expected: 'TypeError'
    actual:   'TypeError [ERR_INVALID_ARG_TYPE]'
    at: Test.test (/Users/mohamed.khalfella/test2/list-directories/test.js:47:5)
    stack: |-
      Error: should fail when it takes a non-string argument.
          at Test.assert [as _assert] (/Users/mohamed.khalfella/test2/list-directories/node_modules/tape/lib/test.js:212:54)
          at Test.bound [as _assert] (/Users/mohamed.khalfella/test2/list-directories/node_modules/tape/lib/test.js:64:32)
          at Test.equal.Test.equals.Test.isEqual.Test.is.Test.strictEqual.Test.strictEquals (/Users/mohamed.khalfella/test2/list-directories/node_modules/tape/lib/test.js:347:10)
          at Test.bound [as equal] (/Users/mohamed.khalfella/test2/list-directories/node_modules/tape/lib/test.js:64:32)
          at Test.test (/Users/mohamed.khalfella/test2/list-directories/test.js:47:5)
```

